### PR TITLE
Disable faster looting while hovering the TSMDestroyBtn frame

### DIFF
--- a/Leatrix_Plus.lua
+++ b/Leatrix_Plus.lua
@@ -1125,6 +1125,11 @@
 
 		if LeaPlusLC["FasterLooting"] == "On" then
 
+			-- Don't run faster looting when the TSM Destroy button is hovered
+			if GetMouseFocus():GetName() == "TSMDestroyBtn" then
+				return
+			end
+
 			-- Time delay
 			local tDelay = 0
 


### PR DESCRIPTION
Hello, thank you for this amazing project!

This PR is related to the issue #66 

I was wondering if there's a way to fix that, so I found how it could work well enough at least for me.

To me it still looks more like a hack, but I'm not very familiar with the API, probably this PR could give you some idea how to fix the TSM conflict. Basically this PR just disables faster looting while the cursor is on "Destroy" TSM button.